### PR TITLE
CopyPathコマンドを分割しcommandsをリンク

### DIFF
--- a/nvim/commands/copy_path.vim
+++ b/nvim/commands/copy_path.vim
@@ -1,0 +1,2 @@
+" 現在のファイルのパスをクリップボードにコピーする
+command! CopyPath let @+ = expand('%:.')

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -55,6 +55,7 @@ endif
 runtime! settings.vim
 runtime! mappings.vim
 runtime! filetypes.vim
+runtime! commands/*.vim
 
 " VimのUndoを永続化する
 if has('persistent_undo')
@@ -83,6 +84,3 @@ require'nvim-treesitter.configs'.setup {
   }
 }
 EOF
-
-" 現在のファイルのパスをクリップボードにコピーする
-command! CopyPath let @+ = expand('%:.')

--- a/symbolic_links.sh
+++ b/symbolic_links.sh
@@ -11,7 +11,7 @@ ln -sf $DOTFILES_PATH/tmux/.tmux.conf ~/.tmux.conf
 ln -sf $DOTFILES_PATH/git/.gitconfig ~/.gitconfig
 ln -sf $DOTFILES_PATH/.ripgreprc ~/.ripgreprc
 
-mkdir -p $HOME/.config/nvim/plugins $HOME/.config/nvim/undo
+mkdir -p $HOME/.config/nvim/plugins $HOME/.config/nvim/commands $HOME/.config/nvim/undo
 
 NVIM_FILES=$(ls -aF $DOTFILES_PATH/nvim/ | grep -v /)
 
@@ -25,6 +25,13 @@ NVIM_PLUGIN_FILES=$(ls -aF $DOTFILES_PATH/nvim/plugins | grep -v /)
 for file in ${NVIM_PLUGIN_FILES[@]}
 do
   ln -sf $DOTFILES_PATH/nvim/plugins/$file ~/.config/nvim/plugins/$file
+done
+
+NVIM_COMMAND_FILES=$(ls -aF $DOTFILES_PATH/nvim/commands | grep -v /)
+
+for file in ${NVIM_COMMAND_FILES[@]}
+do
+  ln -sf $DOTFILES_PATH/nvim/commands/$file ~/.config/nvim/commands/$file
 done
 
 mkdir -p $HOME/.codex


### PR DESCRIPTION
## 概要
- CopyPathコマンドを1ファイル1コマンド構成に分割
- nvim/commandsをシンボリックリンク対象に追加

## 変更点
- nvim/commands/copy_path.vimを追加しCopyPathを移動
- nvim/init.vimでcommands配下を読み込むよう変更
- symbolic_links.shでcommands配下をリンク

## 影響範囲
- Neovimの設定読み込み
- シンボリックリンク作成スクリプト

## テスト
- DOTFILES_PATH=/Users/kamiyamakeigo/dev/dotfiles sh ./symbolic_links.sh
