### PR TITLE
環境設定ファイルをGit管理対象外にします

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .gitconfig
 .aider*
+
+.envrc


### PR DESCRIPTION
## 概要
- .envrc をGit管理対象外にするため .gitignore に追加しました。

## 変更点
- .gitignore に .envrc を追記

## 影響範囲
- なし（.envrc のGit管理のみ変更）

## テスト
- 未実施（設定変更のみ）