### PR TITLE
zshrcにGoバイナリ用PATHを追加

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -73,6 +73,11 @@ eval "$(direnv hook zsh)"
 export PATH="$HOME/.npm-global/bin:$PATH"
 # ----------------
 
+# ----------------
+# goを使って入れたライブラリを使えるようにパスを通す
+export PATH="$HOME/go/bin:$PATH"
+# ----------------
+
 
 # ----------------
 # 詳細設定


### PR DESCRIPTION
## 概要
  `zsh/.zshrc`にGoでインストールしたCLIを利用するためのPATH設定を追加しました。

  ## 変更点
  - `zsh/.zshrc` に以下を追加
    - `export PATH="$HOME/go/bin:$PATH"`

  ## 影響範囲
  - zshのシェル環境設定

  ## テスト
  - 設定ファイル変更のみのため、自動テストは実施していません。