### PR TITLE
zsh で yaegi を rlwrap 経由で実行できるようにします

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -216,6 +216,8 @@ abbrev-alias mv='mv -i'
 abbrev-alias mkdir='mkdir -p'
 abbrev-alias d-c='docker compose'
 abbrev-alias nv='nvim'
+# yaegi で入力履歴と行編集を使えるようにし、毎回 rlwrap を付ける手間を減らす
+abbrev-alias yaegi='rlwrap yaegi'
 abbrev-alias tm='tmux'
 abbrev-alias tm-kill='tmux kill-session'
 abbrev-alias tm-re='tmux a -t 0'


### PR DESCRIPTION
## 概要

  zsh から yaegi を実行する際に、毎回 rlwrap を付けずに済むよう設定を追加します。

  ## 変更点

  zsh/.zshrc に yaegi 用の abbrev-alias を追加しました。
  alias の意図が分かるよう、理由コメントも追加しました。

  ## 影響範囲

  zsh から yaegi を起動する操作に影響します。

  ## テスト

  zsh -n zsh/.zshrc