### PR TITLE
gitconfigのquotepath設定を追加しました

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -79,6 +79,7 @@
 [core]
   editor = nvim
   symlinks = false
+  quotepath = false
 
 [pager]
   diff = delta


### PR DESCRIPTION
## 概要
  git のパス表示でエスケープ表記を避けるため、gitconfig に quotepath 設定を追加しました。

  ## 変更点
  - [core] に `quotepath = false` を追加しました

  ## 影響範囲
  - 日本語など非ASCII文字を含むパスの表示が読みやすくなります

  ## テスト
  - `git diff -- git/.gitconfig` で差分を確認しました